### PR TITLE
Fix lattice planner segmentation fault

### DIFF
--- a/src/state_lattice_planner.cpp
+++ b/src/state_lattice_planner.cpp
@@ -213,7 +213,7 @@ int main(){
   //uniform_terminal_state_sample_test1();
   std::vector<std::vector<float>> lookup_table;
 
-  std::ifstream file("../../lookuptable.csv");
+  std::ifstream file("../lookuptable.csv");
   CSVIterator loop(file);
   loop++;
   for(; loop != CSVIterator(); ++loop)


### PR DESCRIPTION
The location of the lookup table likely changed, causing a segmentation fault if we do not fix the path.